### PR TITLE
Added `-D SELECTHXML_NO_REGEX_PARSING` to disable the use of RegexLexer.

### DIFF
--- a/src/selecthxml/SelectDom.hx
+++ b/src/selecthxml/SelectDom.hx
@@ -74,7 +74,7 @@ class SelectDom
 	
 	static public function runtimeSelect<T>(xml:TypedXml<T>, selectionString:String)
 	{
-		#if flash8
+		#if (flash8 || SELECTHXML_NO_REGEX_PARSING)
 		var lexer = new selecthxml.engine.Lexer(new haxe.io.StringInput(selectionString));
 		#else
 		var lexer = new selecthxml.engine.RegexLexer(selectionString);


### PR DESCRIPTION
Not sure why but the java target throws an exception complaining the regex. Anyway, i think being able to disable the use of RegexLexer is nice since regex support is perform-dependent.
